### PR TITLE
Enable HPA and metrics-server; update resource quotas

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,21 +10,22 @@ DOCKER_BUILD := eval $$(minikube -p $(MINIKUBE_PROFILE) docker-env) && docker bu
 .PHONY: help
 help:
 	@echo "SecurePay Development Commands:"
-	@echo "  make ping          - Ping the cluster"
-	@echo "  make start         - Start Minikube cluster"
-	@echo "  make stop          - Stop Minikube cluster"
-	@echo "  make delete        - Delete Minikube cluster"
-	@echo "  make infrastructure - Install all infrastructure (Spire, Kafka, Redis, Jaeger)"
-	@echo "  make spire         - Install and Configure SPIRE"
-	@echo "  make spire-register - Register workloads with SPIRE"
-	@echo "  make kafka         - Install Kafka"
-	@echo "  make redis         - Install Redis"
-	@echo "  make jaeger        - Install Jaeger"
-	@echo "  make build         - Build all service Docker images"
-	@echo "  make deploy        - Deploy application manifests to K8s"
-	@echo "  make all           - Start, Infra, Build, Deploy"
-	@echo "  make test          - Run end-to-end payment test"
-	@echo "  make clean         - Remove all resources"
+	@echo "  make ping            - Ping the cluster"
+	@echo "  make start           - Start Minikube cluster"
+	@echo "  make stop            - Stop Minikube cluster"
+	@echo "  make delete          - Delete Minikube cluster"
+	@echo "  make infrastructure  - Install all infrastructure (Spire, Kafka, Redis, Jaeger)"
+	@echo "  make spire           - Install and Configure SPIRE"
+	@echo "  make spire-register  - Register workloads with SPIRE"
+	@echo "  make kafka           - Install Kafka"
+	@echo "  make redis           - Install Redis"
+	@echo "  make jaeger          - Install Jaeger"
+	@echo "  make metrics-server  - Deploy metrics-server (required for HPA)"
+	@echo "  make build           - Build all service Docker images"
+	@echo "  make deploy          - Deploy metrics-server + application manifests + HPAs"
+	@echo "  make all             - Start, Infra, Build, Deploy"
+	@echo "  make test            - Run end-to-end payment test"
+	@echo "  make clean           - Remove all resources"
 
 
 # --- Ping ---
@@ -109,8 +110,15 @@ build:
 	$(DOCKER_BUILD) -t securepay/account-service:v0.0.3 account-service/
 	$(DOCKER_BUILD) -t securepay/notification-service:v0.0.5 notification-service/
 
+.PHONY: metrics-server
+metrics-server:
+	@echo "Deploying metrics-server..."
+	$(KUBECTL) apply -f k8s/metrics-server.yaml
+	@echo "Waiting for metrics-server to be ready..."
+	$(KUBECTL) wait --for=condition=available deployment/metrics-server -n kube-system --timeout=120s
+
 .PHONY: deploy
-deploy:
+deploy: metrics-server
 	@echo "Deploying application..."
 	$(KUBECTL) apply -f k8s/api-gateway/
 	$(KUBECTL) apply -f k8s/payment-service/

--- a/k8s/account-service/account-service-deployment.yaml
+++ b/k8s/account-service/account-service-deployment.yaml
@@ -6,7 +6,6 @@ metadata:
   labels:
     app: account-service
 spec:
-  replicas: 1
   selector:
     matchLabels:
       app: account-service

--- a/k8s/account-service/account-service-hpa.yaml
+++ b/k8s/account-service/account-service-hpa.yaml
@@ -1,0 +1,34 @@
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: account-service-hpa
+  namespace: default
+  labels:
+    app: account-service
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: account-service
+  minReplicas: 2
+  maxReplicas: 5
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 70
+  behavior:
+    scaleUp:
+      stabilizationWindowSeconds: 60
+      policies:
+        - type: Pods
+          value: 2
+          periodSeconds: 60
+    scaleDown:
+      stabilizationWindowSeconds: 300
+      policies:
+        - type: Pods
+          value: 1
+          periodSeconds: 120

--- a/k8s/account-service/account-service-memory.yaml
+++ b/k8s/account-service/account-service-memory.yaml
@@ -1,4 +1,16 @@
 apiVersion: v1
+kind: ResourceQuota
+metadata:
+  name: account-service-quota
+  namespace: default
+spec:
+  hard:
+    requests.cpu: "500m"
+    requests.memory: 640Mi
+    limits.cpu: "2500m"
+    limits.memory: 2560Mi
+---
+apiVersion: v1
 kind: LimitRange
 metadata:
   name: account-service-limit-range

--- a/k8s/metrics-server.yaml
+++ b/k8s/metrics-server.yaml
@@ -1,0 +1,206 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    k8s-app: metrics-server
+  name: metrics-server
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    k8s-app: metrics-server
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
+  name: system:aggregated-metrics-reader
+rules:
+  - apiGroups:
+      - metrics.k8s.io
+    resources:
+      - pods
+      - nodes
+    verbs:
+      - get
+      - list
+      - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    k8s-app: metrics-server
+  name: system:metrics-server
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - nodes/metrics
+    verbs:
+      - get
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+      - nodes
+    verbs:
+      - get
+      - list
+      - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    k8s-app: metrics-server
+  name: metrics-server:system:auth-delegator
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:auth-delegator
+subjects:
+  - kind: ServiceAccount
+    name: metrics-server
+    namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    k8s-app: metrics-server
+  name: system:metrics-server
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:metrics-server
+subjects:
+  - kind: ServiceAccount
+    name: metrics-server
+    namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    k8s-app: metrics-server
+  name: metrics-server-auth-reader
+  namespace: kube-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: extension-apiserver-authentication-reader
+subjects:
+  - kind: ServiceAccount
+    name: metrics-server
+    namespace: kube-system
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    k8s-app: metrics-server
+  name: metrics-server
+  namespace: kube-system
+spec:
+  ports:
+    - name: https
+      port: 443
+      protocol: TCP
+      targetPort: https
+  selector:
+    k8s-app: metrics-server
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    k8s-app: metrics-server
+  name: metrics-server
+  namespace: kube-system
+spec:
+  selector:
+    matchLabels:
+      k8s-app: metrics-server
+  strategy:
+    rollingUpdate:
+      maxUnavailable: 0
+  template:
+    metadata:
+      labels:
+        k8s-app: metrics-server
+    spec:
+      containers:
+        - args:
+            - --cert-dir=/tmp
+            - --secure-port=10250
+            - --kubelet-preferred-address-types=InternalIP,ExternalIP,Hostname
+            - --kubelet-use-node-status-port
+            - --metric-resolution=15s
+            # Required for Minikube: skips TLS cert verification against kubelet
+            - --kubelet-insecure-tls
+          image: registry.k8s.io/metrics-server/metrics-server:v0.7.2
+          imagePullPolicy: IfNotPresent
+          livenessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /livez
+              port: https
+              scheme: HTTPS
+            periodSeconds: 10
+          name: metrics-server
+          ports:
+            - containerPort: 10250
+              name: https
+              protocol: TCP
+          readinessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /readyz
+              port: https
+              scheme: HTTPS
+            initialDelaySeconds: 20
+            periodSeconds: 10
+          resources:
+            requests:
+              cpu: 100m
+              memory: 200Mi
+            limits:
+              cpu: 200m
+              memory: 256Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 1000
+            seccompProfile:
+              type: RuntimeDefault
+          volumeMounts:
+            - mountPath: /tmp
+              name: tmp-dir
+      nodeSelector:
+        kubernetes.io/os: linux
+      priorityClassName: system-cluster-critical
+      serviceAccountName: metrics-server
+      volumes:
+        - emptyDir: {}
+          name: tmp-dir
+---
+apiVersion: apiregistration.k8s.io/v1
+kind: APIService
+metadata:
+  labels:
+    k8s-app: metrics-server
+  name: v1beta1.metrics.k8s.io
+spec:
+  group: metrics.k8s.io
+  groupPriorityMinimum: 100
+  insecureSkipTLSVerify: true
+  service:
+    name: metrics-server
+    namespace: kube-system
+  version: v1beta1
+  versionPriority: 100

--- a/k8s/payment-service/payment-service-deployment.yaml
+++ b/k8s/payment-service/payment-service-deployment.yaml
@@ -6,7 +6,6 @@ metadata:
   labels:
     app: payment-service
 spec:
-  replicas: 1
   selector:
     matchLabels:
       app: payment-service

--- a/k8s/payment-service/payment-service-hpa.yaml
+++ b/k8s/payment-service/payment-service-hpa.yaml
@@ -1,0 +1,34 @@
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: payment-service-hpa
+  namespace: default
+  labels:
+    app: payment-service
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: payment-service
+  minReplicas: 2
+  maxReplicas: 5
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 70
+  behavior:
+    scaleUp:
+      stabilizationWindowSeconds: 60
+      policies:
+        - type: Pods
+          value: 2
+          periodSeconds: 60
+    scaleDown:
+      stabilizationWindowSeconds: 300
+      policies:
+        - type: Pods
+          value: 1
+          periodSeconds: 120

--- a/k8s/payment-service/payment-service-memory.yaml
+++ b/k8s/payment-service/payment-service-memory.yaml
@@ -5,10 +5,10 @@ metadata:
   namespace: default
 spec:
   hard:
-    requests.cpu: "1"
-    requests.memory: 1Gi
-    limits.cpu: "2"
-    limits.memory: 2Gi
+    requests.cpu: "500m"
+    requests.memory: 640Mi
+    limits.cpu: "2500m"
+    limits.memory: 2560Mi
 ---
 apiVersion: v1
 kind: LimitRange


### PR DESCRIPTION

## Summary

Adds Horizontal Pod Autoscaling (HPA) for `payment-service` and `account-service`. Deploys `metrics-server` as a prerequisite, removes hard-coded `replicas: 1` from both Deployments (HPA now owns replica management), and introduces `HorizontalPodAutoscaler` objects that scale between 2 and 5 replicas when average CPU utilisation exceeds 70%. A `ResourceQuota` is added for `account-service` and both service quotas are recalculated to accommodate up to 5 pods at peak.

## Motivation / Linked Issue

Closes #2

Services were pinned at a single replica with no automatic scale-out, causing degraded throughput and single-point-of-failure risk under elevated load. This PR resolves that by wiring HPA against live CPU metrics provided by `metrics-server`.

## Type of Change

- [ ] Bug fix (non-breaking)
- [x] New feature (non-breaking)
- [ ] Breaking change (existing behaviour changes)
- [ ] Refactor / internal improvement
- [ ] Dependency update
- [ ] Documentation / comments only
- [ ] CI / workflow change
- [ ] Security improvement

## Services / Components Affected

- [ ] `api-gateway`
- [x] `account-service`
- [x] `payment-service`
- [ ] `notification-service`
- [ ] `proto` (shared protobuf definitions)
- [x] `k8s` (Kubernetes manifests)
- [ ] `.github` (CI workflows / templates)
- [ ] Other:

**Files changed:**

| File | Change |
|---|---|
| [k8s/metrics-server.yaml](cci:7://file://wsl.localhost/Ubuntu/home/doguhan/securepay/securepay/k8s/metrics-server.yaml:0:0-0:0) | New — full metrics-server v0.7.2 manifest (RBAC, Deployment, APIService) |
| [k8s/payment-service/payment-service-hpa.yaml](cci:7://file://wsl.localhost/Ubuntu/home/doguhan/securepay/securepay/k8s/payment-service/payment-service-hpa.yaml:0:0-0:0) | New — HPA for `payment-service` |
| [k8s/account-service/account-service-hpa.yaml](cci:7://file://wsl.localhost/Ubuntu/home/doguhan/securepay/securepay/k8s/account-service/account-service-hpa.yaml:0:0-0:0) | New — HPA for `account-service` |
| [k8s/payment-service/payment-service-deployment.yaml](cci:7://file://wsl.localhost/Ubuntu/home/doguhan/securepay/securepay/k8s/payment-service/payment-service-deployment.yaml:0:0-0:0) | Removed `replicas: 1`; HPA owns replica count |
| [k8s/account-service/account-service-deployment.yaml](cci:7://file://wsl.localhost/Ubuntu/home/doguhan/securepay/securepay/k8s/account-service/account-service-deployment.yaml:0:0-0:0) | Removed `replicas: 1`; HPA owns replica count |
| [k8s/payment-service/payment-service-memory.yaml](cci:7://file://wsl.localhost/Ubuntu/home/doguhan/securepay/securepay/k8s/payment-service/payment-service-memory.yaml:0:0-0:0) | ResourceQuota recalculated for 5-replica ceiling |
| [k8s/account-service/account-service-memory.yaml](cci:7://file://wsl.localhost/Ubuntu/home/doguhan/securepay/securepay/k8s/account-service/account-service-memory.yaml:0:0-0:0) | ResourceQuota added; recalculated for 5-replica ceiling |
| [Makefile](cci:7://file://wsl.localhost/Ubuntu/home/doguhan/securepay/securepay/Makefile:0:0-0:0) | Added `metrics-server` target; `deploy` depends on it |

## How Was It Tested?

```bash
# Deploy metrics-server and verify it becomes available
make metrics-server
kubectl get apiservice v1beta1.metrics.k8s.io

# Deploy services including HPAs
make deploy

# Confirm HPAs are active and reading live metrics
kubectl get hpa -n default
# Expected: TARGETS shows real CPU%, not <unknown>

# Simulate load on payment-service and observe scale-out
kubectl run -it --rm load-gen --image=busybox --restart=Never -- \
  /bin/sh -c "while true; do wget -q -O- http://payment-service:8081/health; done"

# Watch replica count climb
kubectl get hpa payment-service-hpa -n default -w

# Verify ResourceQuota headroom
kubectl describe resourcequota payment-service-quota -n default
kubectl describe resourcequota account-service-quota -n default
```

**Test results:**

- [ ] Unit tests pass (`go test ./...`)
- [ ] `go vet ./...` clean
- [ ] `gofmt` clean
- [ ] Logs verified in JSON with `trace_id` / `span_id` fields populated
- [x] Tested end-to-end in Minikube (if applicable)

## Observability Checklist

Not applicable — this PR touches only Kubernetes manifests and the Makefile. No application code was modified.

## Security Checklist

- [x] No secrets, credentials, or PII are logged
- [x] SPIFFE/SPIRE mTLS is not weakened by this change
- [x] No new network endpoints are exposed without authentication

> `metrics-server` runs in `kube-system` namespace and communicates with the kubelet over the existing node-internal TLS channel. The `--kubelet-insecure-tls` flag is scoped to the Minikube local cluster only and does not affect production.

## Screenshots / Log Samples

Not applicable.

## Reviewer Notes

1. **`replicas` field intentionally absent** from both Deployment specs. If `replicas` is present alongside an HPA, `kubectl apply` resets the count to the manifest value on every deployment, overriding whatever the HPA computed. The HPA `minReplicas: 2` acts as the floor on first apply.

2. **Scale-down is deliberately conservative** — 5-minute stabilisation window, 1 pod per 2 minutes — to avoid replica flapping on bursty traffic.

3. **`metrics-server` uses `--kubelet-insecure-tls`** — required for Minikube because the kubelet self-signed cert doesn't match the node IP. Remove this flag if deploying to a production cluster with proper cert infrastructure.

4. **ResourceQuota scoping** — both quotas live in the `default` namespace and are additive on top of [default-namespace-quota.yaml](cci:7://file://wsl.localhost/Ubuntu/home/doguhan/securepay/securepay/k8s/default-namespace-quota.yaml:0:0-0:0). Verify the combined totals don't exceed the global quota when all services are at max replicas.

## Pre-merge Checklist (for the PR author)

- [x] PR title follows Conventional Commits: `feat(k8s): add HPA for payment-service and account-service (#2)`
- [ ] Branch is up-to-date with `master`
- [ ] CI workflow `PR – Structured Logging` is green
- [ ] At least one reviewer approved
- [ ] `CHANGELOG.md` updated (if the project maintains one)